### PR TITLE
Dockerfile now enforces pinned Python dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,11 @@ WORKDIR /app
 # Copy the Python script into the container
 COPY discord_google_calendar_bot.py /app/
 
-# Install dependencies
-RUN pip install --no-cache-dir discord.py google-api-python-client google-auth boto3
+# Copy the Python script into the container
+COPY requirements.txt /app/
+
+# Install version-pinned dependencies
+RUN pip install -r requirements.txt
 
 # Run the Python script continuously
 CMD ["python", "discord_google_calendar_bot.py"]


### PR DESCRIPTION
Dockerfile now uses requirements.txt. This will help the project align with Dependabot dependency security scans/checks.