### PR TITLE
Fix systemd install script blocking when giving service status

### DIFF
--- a/install_and_start_with_systemd.sh
+++ b/install_and_start_with_systemd.sh
@@ -41,7 +41,7 @@ sudo systemctl start discord-google-calendar-bot
 echo ""
 echo "The bot has been started as a systemd service:"
 echo ""
-sudo systemctl status discord-google-calendar-bot
+SYSTEMD_PAGER=cat systemctl status discord-google-calendar-bot
 echo ""
 echo "Other operational things you can do with the container:"
 echo ""


### PR DESCRIPTION
"systemctl status" now no longer get stuck in "less", requiring operator intervention for the systemd install script to finish running